### PR TITLE
Fixing core dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
   ],
   "require": {
     "php": "~7.4",
-    "magento/framework": "102.0.*|103.0.*",
-    "magento/module-backend": "101.0.*|102.0.*"
+    "magento/framework": "102.0.* || 103.0.*",
+    "magento/module-backend": "101.0.* || 102.0.*"
   },
   "type": "magento2-module",
   "autoload": {


### PR DESCRIPTION
According to https://getcomposer.org/doc/articles/versions.md#version-range, a double pipe will be treated as OR.
A single pipe ignores the second part in my tests.
This way this module is not compatible with PHP 7.4 or Magento 2.4.2-p1